### PR TITLE
Add possibility to decode a PDF providing directly the file content

### DIFF
--- a/src/Pdf2text.php
+++ b/src/Pdf2text.php
@@ -178,7 +178,7 @@ class Pdf2text
 	 */
 	public function decodeContent($pdfContent, $convertQuotes = ENT_QUOTES, $showProgress = false, $multiByteUnicode = true)
 	{
-                $this->saveOptions($fileName, $convertQuotes, $showProgress, $multiByteUnicode);
+                $this->saveOptions(null, $convertQuotes, $showProgress, $multiByteUnicode);
 		$this->decodePDF($pdfContent);
 		return $this->output();
 	}


### PR DESCRIPTION
In some cases the PDF file content is already in memory,
with the new function decodeContent is possible to decode it directly.

The compatibility with previous versions is maintained and the decode function is keeping the same signature.

The phpunit test is running correctly.